### PR TITLE
Bug/MOV-84 Fixed the bug where the Change Password Before Login wasn't actually changing the password.

### DIFF
--- a/src/main/java/org/loose/fis/mov/controllers/ChangePasswordBeforeLogInController.java
+++ b/src/main/java/org/loose/fis/mov/controllers/ChangePasswordBeforeLogInController.java
@@ -11,6 +11,7 @@ import java.util.Properties;
 import javafx.event.ActionEvent;
 import org.loose.fis.mov.exceptions.UserNotRegisteredException;
 import org.loose.fis.mov.model.User;
+import org.loose.fis.mov.services.UserService;
 
 import javax.mail.*;
 import javax.mail.internet.InternetAddress;
@@ -33,10 +34,9 @@ public  class ChangePasswordBeforeLogInController extends AbstractController{
     @FXML
     public void switchToRegisterWithPassword(ActionEvent event) throws IOException, UserNotRegisteredException {
         String email = emailTextField.getText();
-        User user=findUserByEmail(email);
         String newPassword=WordGenerator(12);
-        user.setPassword(newPassword);
-        sendMail(email,"Kingule ti-o picat parola","Parola ta este: " + newPassword + " Sa nu spui la nimeni;)");
+        UserService.changePassword(email, newPassword);
+        sendMail(email,"Moviefy Password Reset","Your new password is: " + newPassword);
         changeScene(event, "login.fxml");
     }
 }

--- a/src/main/java/org/loose/fis/mov/services/UserService.java
+++ b/src/main/java/org/loose/fis/mov/services/UserService.java
@@ -41,6 +41,12 @@ public class UserService {
         SessionService.destroySession();
     }
 
+    public static void changePassword(String email, String newPassword) throws UserNotRegisteredException {
+        User user = findUserByEmail(email);
+        user.setPassword(encodePassword(user.getUsername(), newPassword));
+        DatabaseService.getUserRepo().update(user);
+    }
+
     private static User findUser(String username) throws UserNotRegisteredException {
         User user = DatabaseService.getUserRepo().find(eq("username", username)).firstOrDefault();
         if (user == null) {

--- a/src/test/java/org/loose/fis/mov/services/UserServiceTest.java
+++ b/src/test/java/org/loose/fis/mov/services/UserServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.loose.fis.mov.exceptions.*;
+import org.loose.fis.mov.model.User;
 
 import java.io.IOException;
 
@@ -21,8 +22,14 @@ class UserServiceTest {
 
     @AfterEach
     void tearDown() throws IOException {
-        DatabaseService.closeDatabase();
-        FileUtils.cleanDirectory(FileSystemService.getApplicationHomePath().toFile());
+        try {
+            SessionService.destroySession();
+        } catch (SessionDoesNotExistException ignored) {
+
+        } finally {
+            DatabaseService.closeDatabase();
+            FileUtils.cleanDirectory(FileSystemService.getApplicationHomePath().toFile());
+        }
     }
 
     @Test
@@ -82,6 +89,18 @@ class UserServiceTest {
         assertThrows(SessionDoesNotExistException.class, () -> {
             UserService.logout();
             UserService.logout();
+        });
+    }
+
+    @Test
+    void changePassword() {
+        assertDoesNotThrow(() -> {
+           UserService.addUser(
+                   "test", "test", "test", "test_test",
+                   "test@test.test", "Client", "", "", ""
+           );
+           UserService.changePassword("test@test.test", "new_test_test");
+           UserService.login("test", "new_test_test");
         });
     }
 }


### PR DESCRIPTION
This was necessary because generating a new password in the Change Password Before Login screen only updated the User object in memory but not the database file.

Also created a dedicated static method in `UserService` for handling password changes. It will be necessary for a future story.

Unit tested to make sure the bug fix works.
