### PR TITLE
bug/MOV-92 Fixed the bug where Clients had the same menu as admins.

### DIFF
--- a/src/main/java/org/loose/fis/mov/controllers/UserProfileController.java
+++ b/src/main/java/org/loose/fis/mov/controllers/UserProfileController.java
@@ -2,6 +2,7 @@ package org.loose.fis.mov.controllers;
 
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.scene.control.Hyperlink;
 import javafx.scene.layout.GridPane;
 import javafx.scene.text.Text;
 import org.loose.fis.mov.exceptions.UserNotAdminException;
@@ -15,6 +16,8 @@ import java.util.Objects;
 import static org.dizitart.no2.objects.filters.ObjectFilters.eq;
 
 public class UserProfileController extends AbstractController{
+    @FXML
+    private Hyperlink commonMenuField;
     @FXML
     private Text usernameField;
     @FXML
@@ -42,12 +45,16 @@ public class UserProfileController extends AbstractController{
         cinemaTab.setVisible(false);
 
         if (Objects.equals(user.getRole(), "Admin")) {
+            commonMenuField.setText("Add Screening");
+
             Cinema cinema = CinemaService.findCinemaForAdmin(user);
 
             cinemaTab.setVisible(true);
             cinemaNameField.setText(cinema.getName());
             cinemaAddressField.setText(cinema.getAddress());
             cinemaCapacityField.setText(String.valueOf(cinema.getCapacity()));
+        } else {
+            commonMenuField.setText("My Bookings");
         }
     }
 
@@ -67,7 +74,8 @@ public class UserProfileController extends AbstractController{
     }
 
     @FXML
-    public void handleMenuAddScreening(ActionEvent event) {
+    public void handleMenuCommonField(ActionEvent event) {
+        // must branch into admin and client users after merging the add screening story;
         System.out.println("Not yet implemented.");
     }
 

--- a/src/main/resources/userProfile.fxml
+++ b/src/main/resources/userProfile.fxml
@@ -18,7 +18,7 @@
          <children>
             <Hyperlink onAction="#handleMenuHome" prefHeight="29.0" text="Home" textAlignment="CENTER" />
             <Hyperlink onAction="#handleMenuMyProfile" prefHeight="29.0" prefWidth="62.0" text="My Profile" textAlignment="CENTER" />
-            <Hyperlink onAction="#handleMenuAddScreening" prefHeight="31.0" text="Add Screening" textAlignment="CENTER" />
+            <Hyperlink fx:id="commonMenuField" onAction="#handleMenuCommonField" prefHeight="31.0" textAlignment="CENTER" />
             <Hyperlink onAction="#handleMenuLogout" prefHeight="31.0" text="Logout" textAlignment="CENTER" />
          </children>
       </HBox>


### PR DESCRIPTION
The User Profile page displayed the Admin top menu options for both Clients and Admins alike. It was patched by turning the "Add Screening" option into an option shared by both user types. Based on the logged in user, this Menu Option will be filled dinamically with:
- My Bookings for Clients.
- Add Screenings for Admins.