### PR TITLE
MOV-118 Fixed the bug where a user can only leave a review globally.

### DIFF
--- a/src/main/java/org/loose/fis/mov/controllers/MainMenuMAINClientController.java
+++ b/src/main/java/org/loose/fis/mov/controllers/MainMenuMAINClientController.java
@@ -11,10 +11,7 @@ import javafx.scene.control.*;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
-import org.loose.fis.mov.model.Cinema;
-import org.loose.fis.mov.model.Movie;
-import org.loose.fis.mov.model.Review;
-import org.loose.fis.mov.model.Screening;
+import org.loose.fis.mov.model.*;
 import org.loose.fis.mov.services.*;
 
 import java.io.IOException;
@@ -145,19 +142,26 @@ public class MainMenuMAINClientController extends AbstractMenusController implem
                     .getFixedCellSize() + 2);
 
             title.setText(movieTitle.getText());
-            Movie film = null;
 
-            film=MovieService.findMovieByTitle(movieTitle.getText());
+            Movie film = MovieService.findMovieByTitle(movieTitle.getText());
+            User loggedInUser = SessionService.getLoggedInUser();
             SessionService.setSelectedString(film);
-            if(ReviewService.getClientReview(SessionService.getLoggedInUser())==null) {
+            if(ReviewService.getClientReview(loggedInUser.getUsername(),
+                                             film.getTitle()) == null) {
                 addButton.setVisible(true);
                 addButton.setDisable(false);
+                editButton.setVisible(false);
+                editButton.setDisable(true);
+                deleteButton.setVisible(false);
+                deleteButton.setDisable(true);
             }
             else{
+                addButton.setVisible(false);
+                addButton.setDisable(true);
                 editButton.setVisible(true);
-            editButton.setDisable(false);
-            deleteButton.setVisible(true);
-            deleteButton.setDisable(false);
+                editButton.setDisable(false);
+                deleteButton.setVisible(true);
+                deleteButton.setDisable(false);
             }
             subtitle.setText(film.getDescription());
             text.setText(String.valueOf(film.getLength()));

--- a/src/main/java/org/loose/fis/mov/services/ReviewService.java
+++ b/src/main/java/org/loose/fis/mov/services/ReviewService.java
@@ -6,6 +6,7 @@ import org.loose.fis.mov.model.User;
 
 import java.util.List;
 
+import static org.dizitart.no2.objects.filters.ObjectFilters.and;
 import static org.dizitart.no2.objects.filters.ObjectFilters.eq;
 
 public final class ReviewService {
@@ -20,9 +21,13 @@ public final class ReviewService {
         DatabaseService.getReviewRepo().insert(review);
         DatabaseService.getMovieRepo().update(SessionService.getSelectedMovie());
     }
-    public static Review getClientReview(User user){
+
+    public static Review getClientReview(String username, String movieTitle){
         return DatabaseService.getReviewRepo().find(
-                eq("clientUsername", user.getUsername())
+                and(
+                        eq("clientUsername", username),
+                        eq("movieTitle", movieTitle)
+                )
         ).firstOrDefault();
     }
 }


### PR DESCRIPTION
This was caused by the method finding a review left by a user at a movie. Now it is fixed. Also, ADD and REMOVE/DELETE review buttons display accordingly (you cannot add more than one review per movie, only modify or delete the existing one)