### PR TITLE
MOV-132 Now cinema schedules are independent - bug fixed.

### DIFF
--- a/src/main/java/org/loose/fis/mov/services/ScreeningService.java
+++ b/src/main/java/org/loose/fis/mov/services/ScreeningService.java
@@ -86,7 +86,7 @@ public static void updateScreeningSeats(Screening screening,int seats){
         Date upperMarginInterval = calendar.getTime();
 
         // checking if there are any screenings going on in that interval;
-        for (Screening screening : DatabaseService.getScreeningRepo().find().toList()) {
+        for (Screening screening : ScreeningService.findAllFutureScreeningsForCinema(cinema)) {
             Movie movie = MovieService.getMovieForScreening(screening);
 
             // setting the bounds for the found screening interval;


### PR DESCRIPTION
Solves the bug MOV-132 where cinema schedules were not independent. When scheduling a screening for a movie that would overlap with a screening from another cinema, the application would reject the screening, which was unwanted behavior. Each cinema should have its own schedule.